### PR TITLE
Increased precision of COLMAP export by specifying camera parameters datatype

### DIFF
--- a/scripts/dataio/image_data_io.py
+++ b/scripts/dataio/image_data_io.py
@@ -238,10 +238,10 @@ class ImageDataIO:
             local_rotation=camera_characteristics.rot_quat
         )
 
-        fxs = np.full_like(timestamps, camera_characteristics.fx)
-        fys = np.full_like(timestamps, camera_characteristics.fy)
-        cxs = np.full_like(timestamps, camera_characteristics.cx)
-        cys = np.full_like(timestamps, camera_characteristics.cy)
+        fxs = np.full_like(timestamps, camera_characteristics.fx, dtype=np.float32)
+        fys = np.full_like(timestamps, camera_characteristics.fy, dtype=np.float32)
+        cxs = np.full_like(timestamps, camera_characteristics.cx, dtype=np.float32)
+        cys = np.full_like(timestamps, camera_characteristics.cy, dtype=np.float32)
         widths = np.full_like(timestamps, camera_characteristics.width)
         heights = np.full_like(timestamps, camera_characteristics.height)
 


### PR DESCRIPTION
While working with the exported colmap data, I realized camera parameters are being casted to integer values, which caused problems later on and lowered overall precision of my localization. Not specifying data types in one of the scripts was guilty. Hope it helps others.