### PR TITLE
Fixing frozen `cv2.cvtColor` calls in `convert_yuv_to_rgb.py`

### DIFF
--- a/scripts/utils/image_utils.py
+++ b/scripts/utils/image_utils.py
@@ -1,4 +1,5 @@
 import cv2
+cv2.setNumThreads(0)
 import numpy as np
 from models.image_format_info import ImageFormatInfo
 


### PR DESCRIPTION
When running `scripts/convert_yuv_to_rgb.py`, I noticed that the `convert_yuv420_888_to_bgr` function was hanging on the `cv2.cvtColor` function since OpenCV does not play well with `ProcessPoolExecutor()`. This PR forces OpenCV to run on a single thread, and works for me.